### PR TITLE
Feature: Filter Tabs by Title

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -3,11 +3,18 @@
 const INITIALIZATION_DELAY = 2000; // 5 seconds in milliseconds
 // looks through a list of search terms and tells you if url is in them
 setTimeout(() => {
-let isSearchTermInUrl =  (url: string, searchTerms: string[]) => {
+let isSearchTermInUrl =  (url: string, title: string | undefined, searchTerms: string[]) => {
   if(searchTerms) {
     for(let i = 0; i < searchTerms.length; i++) {
-      if(url.includes(searchTerms[i])) {
-        return true;
+      if (title && searchTerms[i].startsWith("t:")){
+        const searchTitle = searchTerms[i].split("t:")[1];
+        if(title.includes(searchTitle)) {
+          return true;
+        }
+      } else {
+        if(url.includes(searchTerms[i])) {
+          return true;
+        }
       }
     }
     return false;
@@ -86,7 +93,7 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
       chrome.storage.sync.set({TABGROUPS: ''})
       return;
     }
-          const { url } = tab;
+          const { url, title } = tab;
           if (Object.keys(chromeStorageTabGroupObject).length !== 0) {
             let ungroup = true;
             let matchingTabGroupInBrowser = false;
@@ -95,7 +102,7 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
               const currentChromeStorageTabGroup = chromeStorageTabGroupObject.TABGROUPS[i];
               if ( Object.prototype.hasOwnProperty.call(currentChromeStorageTabGroup, group) ) {
                 const searchTerms = currentChromeStorageTabGroup[group].URL;
-                if (isSearchTermInUrl(url, searchTerms)) {
+                if (isSearchTermInUrl(url, title, searchTerms)) {
                   ungroup = false
                   matchingTabGroupInBrowser = groupTabIfTabGroupExistsInBrowser(browserTabGroupObject, currentChromeStorageTabGroup[group], tabId);
                   // if tab doesn't have a group id already and no other tabs following that same


### PR DESCRIPTION
This PR introduces the functionality of filtering browser tabs based on their title, extending the existing features. This allows users to more precisely manage their tab groups, especially in scenarios where multiple tabs from the same domain/URL are open but have different titles.

### How to use

Add value to "Domain / URL" that begins with `t:`.
Example: `t:MyTitle`.
It also supports mixing URLs and title filters: `microsoft.com, t:MyTitle`

### Extension configuration
<img width="400" alt="TabTitleConfig" src="https://github.com/furofo/TabGroupExtension/assets/6381768/4f28097b-c87d-4745-bdb0-7e5dd1c48379">

### Resulting in tabs

<img width="600" alt="Tabs" src="https://github.com/furofo/TabGroupExtension/assets/6381768/fe1ce954-3681-4707-aa94-3f3be4bcded8">
